### PR TITLE
Improve parsing and speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a plugin for [Calibre](https://calibre-ebook.com/) which allows you to search [libgen.is](https://libgen.is) for books using Calibre's search for e-books feature
 
 ## Installation
+
 - Download the zip file from the releases page
 - Open Calibre
 - Go to **Preferences -> Plugins -> Load Plugin from File** and select the zip file you downloaded.
@@ -10,5 +11,7 @@ This is a plugin for [Calibre](https://calibre-ebook.com/) which allows you to s
 - Make sure the store is enabled under **Get Books -> Choose Stores**
 
 ## Tips
-Due to the way Calibre store plugins work, only a maximum of 10 results can be returned at a time.  For better results and to get the format you are looking for, narrow down your search by title and author as much as possible.
 
+Calibre defaults to a maximum of 10 results returned at a time. You can change this maximum at **Get Books -> Configure -> Configure Search -> Maximum number of results...**
+
+For better results and to get the format you are looking for, narrow down your search by title and author as much as possible.

--- a/__init__.py
+++ b/__init__.py
@@ -2,18 +2,18 @@
 # License: GPLv3 Copyright: 2021, winnbyte
 store_version = 8  # Needed for dynamic plugin loading
 
-__license__ = 'GPLv3'
-__copyright__ = 'winnbyte'
-__docformat__ = 'restructuredtext en'
+__license__ = "GPLv3"
+__copyright__ = "winnbyte"
+__docformat__ = "restructuredtext en"
 
 from calibre.customize import StoreBase
 
 
 class LibgenStore(StoreBase):
-    name = 'Library Genesis'
-    version = (1, 0, 0)
-    description = 'Searches for books on Library Genesis'
-    author = 'winnbyte'
+    name = "Library Genesis"
+    version = (1, 0, 1)
+    description = "Searches for books on Library Genesis"
+    author = "winnbyte"
     drm_free_only = True
-    actual_plugin = 'calibre_plugins.store_libgen.libgen_plugin:LibgenStorePlugin'
-    formats = ['EPUB', 'PDF']
+    actual_plugin = "calibre_plugins.store_libgen.libgen_plugin:LibgenStorePlugin"
+    formats = ["EPUB", "PDF"]

--- a/libgen_plugin.py
+++ b/libgen_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import urllib.parse
+import time
 
 from bs4 import BeautifulSoup
 
@@ -15,15 +16,17 @@ from calibre.gui2.store.search_result import SearchResult
 from calibre.gui2.store.basic_config import BasicStoreConfig
 from calibre.gui2.store.web_store_dialog import WebStoreDialog
 
-BASE_URL = 'https://libgen.is'
-USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
+BASE_URL = "https://libgen.is"
+USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko"
 
 #####################################################################
 # Plug-in base class
 #####################################################################
 
+
 def search_libgen(query, max_results=10, timeout=60):
-    search_url = BASE_URL + '/search.php?req=' + query.decode()
+    res = "25" if max_results <= 25 else "50" if max_results <= 50 else "100"
+    search_url = f"{BASE_URL}/search.php?req={query.decode()}&res={res}&view=simple"
     print("searching: " + search_url)
     print("max results: " + str(max_results))
     br = browser(user_agent=USER_AGENT)
@@ -40,31 +43,31 @@ def search_libgen(query, max_results=10, timeout=60):
         if index == 0:
             continue
 
-        tds = item.select('td')
-        detail_url = BASE_URL + "/" + tds[2].select('a')[0].get('href')
-        title = tds[2].select('a')[0].text
-        author = tds[1].select('a')[0].text
+        tds = item.select("td")
+
+        title = tds[2].select("a")[-1].text
+        detail_url = BASE_URL + "/" + tds[2].select("a")[-1].get("href")
+
+        libgen_id = int(tds[0].text)
+        author = tds[1].text
+        series = tds[2].select("a")[0].text if len(tds[2].select("a")) > 1 else None
+        publisher = tds[3].text
+        year = tds[4].text
+        pages = tds[5].text
+        language = tds[6].text
+        size = tds[7].text
         extension = tds[8].text.upper()
+        mirror1_url = tds[9].select("a")[0].get("href")
 
-        mirror1_url = tds[9].select('a')[0].get('href')
-        raw = br.open(mirror1_url).read()
-        soup2 = BeautifulSoup(raw, "html5lib")
-        new_base_url = urllib.parse.urlparse(mirror1_url).hostname
-
-        download_a = soup2.select('div[id="download"] > ul > li > a')[0]
-        download_url = download_a.get("href")
-
-        image_url = 'http://' + new_base_url + soup2.select('img')[0].get('src')
-
-        if title and author and download_url:
-            s = SearchResult()
+        if title and author:
+            s = LibgenSearchResult(libgen_id)
             s.title = title
             s.author = author
-            s.cover_url = image_url
+            s.price = f"{size}\n{pages} pages\n{year}"  # use price column to display more info
             s.detail_item = detail_url
             s.formats = extension
             s.drm = SearchResult.DRM_UNLOCKED
-            s.downloads[extension] = download_url
+            s.mirror1_url = mirror1_url
             count += 1
             yield s
 
@@ -73,19 +76,52 @@ class LibgenStorePlugin(BasicStoreConfig, StorePlugin):
     def open(self, parent=None, detail_item=None, external=False):
         url = BASE_URL
 
-        if external or self.config.get('open_external', False):
+        if external or self.config.get("open_external", False):
             open_url(QUrl(url_slash_cleaner(detail_item if detail_item else url)))
         else:
             d = WebStoreDialog(self.gui, url, parent, detail_item)
             d.setWindowTitle(self.name)
-            d.set_tags(self.config.get('tags', ''))
+            d.set_tags(self.config.get("tags", ""))
             d.exec_()
 
     def search(self, query, max_results=10, timeout=60):
         for result in search_libgen(query, max_results=max_results, timeout=timeout):
             yield result
 
+    def get_details(self, search_result, timeout):
+        s = search_result
+        br = browser(user_agent=USER_AGENT)
+        while True:
+            try:
+                raw = br.open(s.mirror1_url).read()
+                break
+            except:
+                # sever error, retry after delay
+                time.sleep(0.1)
 
-if __name__ == '__main__':
-    for result in search_libgen(bytes(' '.join(sys.argv[1:]), 'utf-8')):
+        soup2 = BeautifulSoup(raw, "html5lib")
+        download_a = soup2.select('div[id="download"] > ul > li > a')[0]
+        download_url = download_a.get("href")
+
+        new_base_url = urllib.parse.urlparse(s.mirror1_url).hostname
+        image_url = "http://" + new_base_url + soup2.select("img")[0].get("src")
+
+        s.downloads[s.formats] = download_url
+        s.cover_url = image_url
+
+
+class LibgenSearchResult(SearchResult):
+    def __init__(self, id):
+        super().__init__()
+        self.id = id
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(self.id)
+
+
+if __name__ == "__main__":
+    for result in search_libgen(bytes(" ".join(sys.argv[1:]), "utf-8")):
         print(result)


### PR DESCRIPTION
LibGen may include book series information in the query result. The series and title information are correctly parsed.

We also moved some workloads to `get_details`. This improves loading speed when a search starts, image URLs and download URLs are later loaded incrementally.